### PR TITLE
Don't reassign int value from `int64`

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,7 +161,7 @@ func listenForMessages(bot *tgbotapi.BotAPI, chatID int64, secret types.Telegram
 					answerCallback(bot, update.CallbackQuery.ID, "Error marking entry as read")
 				} else {
 					bot.DeleteMessage(tgbotapi.NewDeleteMessage(chatID, update.CallbackQuery.Message.MessageID))
-					store.DeleteEntryByID(int(entryID))
+					store.DeleteEntryByID(entryID)
 					answerCallback(bot, update.CallbackQuery.ID, "Deleted message & marked as read")
 				}
 			case deleteMessage:

--- a/main.go
+++ b/main.go
@@ -248,7 +248,7 @@ func sendMsg(bot *tgbotapi.BotAPI, chatID int64, secret types.TelegramSecret, en
 
 	// Save our message
 	var messageEntry models.Message
-	messageEntry.ID = int(entry.ID)
+	messageEntry.ID = entry.ID
 	messageEntry.TelegramID = message.MessageID
 	messageEntry.SentTime = message.Time()
 	err = store.InsertEntry(messageEntry)

--- a/models/models.go
+++ b/models/models.go
@@ -4,7 +4,7 @@ import "time"
 
 // Message is used to contain entries inserted into storage
 type Message struct {
-	ID         int       // ID taken Miniflux's entry ID
+	ID         int64     // ID taken Miniflux's entry ID
 	TelegramID int       // The message ID from Telegram
 	SentTime   time.Time // The time the message was sent
 }

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -105,7 +105,7 @@ func (d db) GetEntries() ([]models.Message, error) {
 	return results, nil
 }
 
-func (d db) DeleteEntryByID(id int) error {
+func (d db) DeleteEntryByID(id int64) error {
 	_, err := d.ctx.Exec(`
 	DELETE from entries where id=?
 	`, id)

--- a/store/store.go
+++ b/store/store.go
@@ -8,6 +8,6 @@ type Store interface {
 	GetEntries() ([]models.Message, error)   // Get all entries in DB
 	GetEntry(id int) (models.Message, error) // Get a single entry in the DB
 	InsertEntry(models.Message) error        // Insert a new entry into the DB
-	DeleteEntryByID(id int) error            // Delete a entry in the DB by Miniflux ID
+	DeleteEntryByID(id int64) error          // Delete a entry in the DB by Miniflux ID
 	DeleteEntryByTelegramID(id int) error    // Delete a entry in the DB by its Telegram ID
 }


### PR DESCRIPTION
This was caught by CodeQL scanning and saves reassigning the `int64` value down to just an `int`
`int64` is what Miniflux stores its entry IDs as so matches what we're given